### PR TITLE
Housekeeping (SBT, Scala, License)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 janjaali
+Copyright (c) 2021 janjaali
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / licenses := Seq(
   "MIT License" -> url("https://opensource.org/licenses/MIT")
 )
 
-ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / scalaVersion := "2.12.13"
 
 ThisBuild / homepage := Some(url("https://github.com/janjaali/scala-compiler-options"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / licenses := Seq(
   "MIT License" -> url("https://opensource.org/licenses/MIT")
 )
 
-ThisBuild / scalaVersion := "2.12.13"
+ThisBuild / scalaVersion := "2.12.14"
 
 ThisBuild / homepage := Some(url("https://github.com/janjaali/scala-compiler-options"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version = 1.5.4


### PR DESCRIPTION
## Contains

* Updates the Scala version to v2.12.14
* Updates the SBT version to v1.5.4
* Updates the MIT license copyright to 2021